### PR TITLE
Implement ZenjectSpawnedInstanceHelper

### DIFF
--- a/Assets/Scripts/ISpawnedInstancePublisher.cs
+++ b/Assets/Scripts/ISpawnedInstancePublisher.cs
@@ -12,7 +12,7 @@ namespace ExtraZenject
     {
         public static void OnSpawn<T>(this ISpawnedInstancePublisher self)
         {
-            self.Publisher.Fire(new SpawnedInstance<T>((T) self));
+            self.Publisher.TryFire(new SpawnedInstance<T>((T) self));
         }
     }
 }

--- a/Assets/Scripts/ISpawnedInstanceReceiver.cs
+++ b/Assets/Scripts/ISpawnedInstanceReceiver.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using UniRx;
+using UniRx.Triggers;
+using UnityEngine;
 using Zenject;
 
 namespace ExtraZenject
@@ -10,11 +14,48 @@ namespace ExtraZenject
         SignalBus Receiver { get; set; }
     }
 
+    public interface IStorableSpawnedInstanceReceiver<T> : ISpawnedInstanceReceiver
+    {
+        IList<T> InstanceList { get; }
+    }
+
     public static class SpawnedInstanceReceiverExtension
     {
         public static IObservable<T> OnSpawnAsObservable<T>(this ISpawnedInstanceReceiver self)
         {
             return self.Receiver.GetStream<SpawnedInstance<T>>().Select(x => x.Instance);
+        }
+
+        public static IDisposable SubscribeSpawn<T>(this IStorableSpawnedInstanceReceiver<T> self)
+        {
+            return self
+                .OnSpawnAsObservable<T>()
+                .Subscribe(
+                    x =>
+                    {
+                        self.InstanceList.Add(x);
+                        if (x is MonoBehaviour monoBehaviour)
+                        {
+                            monoBehaviour
+                                .OnDestroyAsObservable()
+                                .Subscribe(
+                                    _ => self
+                                        .InstanceList
+                                        .Remove(x)
+                                );
+                        }
+                    }
+                );
+        }
+
+        public static void InvokeAll<T>(this IStorableSpawnedInstanceReceiver<T> self, Action<T> callback)
+        {
+            self.InstanceList.ToList().ForEach(callback);
+        }
+
+        public static IEnumerable<TResult> InvokeAll<T, TResult>(this IStorableSpawnedInstanceReceiver<T> self, Func<T, TResult> callback)
+        {
+            return self.InstanceList.ToList().Select(callback);
         }
     }
 }

--- a/Assets/Scripts/SignalBusInstaller.cs
+++ b/Assets/Scripts/SignalBusInstaller.cs
@@ -1,0 +1,12 @@
+using Zenject;
+
+namespace ExtraZenject
+{
+    public class SignalBusInstaller : MonoInstaller<SignalBusInstaller>
+    {
+        public override void InstallBindings()
+        {
+            Zenject.SignalBusInstaller.Install(Container);
+        }
+    }
+}

--- a/Assets/Scripts/SignalBusInstaller.cs.meta
+++ b/Assets/Scripts/SignalBusInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 688aff2f16a34d39995503ab0ab986b3
+timeCreated: 1547803391

--- a/Assets/Scripts/SpawnedInstance.cs
+++ b/Assets/Scripts/SpawnedInstance.cs
@@ -1,3 +1,5 @@
+using Zenject;
+
 namespace ExtraZenject
 {
     public struct SpawnedInstance<T>
@@ -7,6 +9,14 @@ namespace ExtraZenject
         public SpawnedInstance(T instance)
         {
             Instance = instance;
+        }
+    }
+
+    public static class SpawnedInstanceExtension
+    {
+        public static DeclareSignalIdRequireHandlerAsyncTickPriorityCopyBinder DeclareSpawnedSignal<TSignal>(this DiContainer container)
+        {
+            return container.DeclareSignal<SpawnedInstance<TSignal>>();
         }
     }
 }

--- a/Assets/Scripts/ZenjectSpawnedInstanceHelper.cs
+++ b/Assets/Scripts/ZenjectSpawnedInstanceHelper.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using Zenject;
+
+namespace ExtraZenject
+{
+    [RequireComponent(typeof(ZenjectBinding))]
+    public class ZenjectSpawnedInstanceHelper : MonoBehaviour
+    {
+        private ZenjectBinding cachedZenjectBinding;
+        private ZenjectBinding ZenjectBinding => cachedZenjectBinding ? cachedZenjectBinding : (cachedZenjectBinding = GetComponent<ZenjectBinding>());
+
+        private SignalBus SignalBus { get; set; }
+
+        private static Type SpawnedInstanceType { get; } = typeof(SpawnedInstance<>);
+
+        private void Start()
+        {
+            SignalBus =
+                (
+                    // Resolve SignalBus from SceneContext to match context if ZenjectBinding.UseSceneContext is true
+                    ZenjectBinding.UseSceneContext
+                        ? gameObject
+                            .scene
+                            // Expect that there is a SceneContext in Root
+                            .GetRootGameObjects()
+                            .First(x => x.GetComponent<SceneContext>() != null)
+                            .GetComponent<SceneContext>()
+                            .Container
+                        : ProjectContext.Instance.Container
+                )
+                .Resolve<SignalBus>();
+            foreach (var component in ZenjectBinding.Components)
+            {
+                switch (ZenjectBinding.BindType)
+                {
+                    case ZenjectBinding.BindTypes.Self:
+                        SignalBus.TryFire(component.GetType(), component);
+                        break;
+                    case ZenjectBinding.BindTypes.AllInterfaces:
+                        component
+                            .GetType()
+                            .GetInterfaces()
+                            .ToList()
+                            .ForEach(type => InvokeFire(type, component));
+                        break;
+                    case ZenjectBinding.BindTypes.AllInterfacesAndSelf:
+                        component
+                            .GetType()
+                            .GetInterfaces()
+                            .ToList()
+                            .ForEach(type => InvokeFire(type, component));
+                        SignalBus.TryFire(component.GetType(), component);
+                        break;
+                    case ZenjectBinding.BindTypes.BaseType:
+                        if (component.GetType().BaseType != default)
+                        {
+                            InvokeFire(component.GetType().BaseType, component);
+                        }
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        private void InvokeFire(Type type, object instance)
+        {
+            var targetType = SpawnedInstanceType.MakeGenericType(type);
+            SignalBus
+                .GetType()
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .First(
+                    mi =>
+                        mi.Name == "TryFire"
+                        && mi.IsGenericMethod
+                        && mi.IsGenericMethodDefinition
+                        && mi.ContainsGenericParameters
+                        && mi.GetParameters().Length == 2
+                )
+                .MakeGenericMethod(targetType)
+                .Invoke(
+                    SignalBus,
+                    new[]
+                    {
+                        Activator.CreateInstance(targetType, instance),
+                        string.IsNullOrEmpty(ZenjectBinding.Identifier) ? null : ZenjectBinding.Identifier
+                    }
+                );
+        }
+    }
+}

--- a/Assets/Scripts/ZenjectSpawnedInstanceHelper.cs.meta
+++ b/Assets/Scripts/ZenjectSpawnedInstanceHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5a0f1744e8f7430ab793c1b463bc6a97
+timeCreated: 1547798792


### PR DESCRIPTION
Attach `ZenjectSpawnedInstanceHelper` into GameObject that already attached `ZenjectBinding` component, to register automatically SpawnedInstance Signal. 