### PR TITLE
Avoid re-publish when subscribe

### DIFF
--- a/Assets/Scripts/InstanceBroker.cs
+++ b/Assets/Scripts/InstanceBroker.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UniRx;
 using UnityEngine;
@@ -69,8 +69,7 @@ namespace ExtraZenject
         {
             if (ReactivePropertyMap.ContainsKey(type))
             {
-                Debug.LogWarning($"`{type}' has already declared.");
-                return;
+                ((ReactiveProperty<object>) ReactivePropertyMap[type]).Dispose();
             }
 
             ReactivePropertyMap[type] = new ReactiveProperty<object>();


### PR DESCRIPTION
* ReactiveProperty の値が生きている状態で再 Subscribe されると再送されてしまうので、結果として多重呼び出しが行われてしまう